### PR TITLE
Fix issue10 txs wont propagate, closes #10

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -198,6 +198,12 @@ func (app *EthermintApplication) Commit() tmspTypes.Result {
 	app.commitMutex.Lock()
 	defer app.commitMutex.Unlock()
 
+	// if there were nonces bumped by incomming txs, we need to bump them in the PublicTransactionPoolAPI too
+	rememberedManagedState := app.txPool.State()
+	if rememberedManagedState != nil {
+		app.backend.UpdateNonces(rememberedManagedState)
+	}
+
 	// commit ethereum state and update the header
 	hashArray, err := app.blockResults.state.Commit()
 	if err != nil {

--- a/ethereum/backend.go
+++ b/ethereum/backend.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"unsafe"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/state"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/event"
@@ -168,10 +168,10 @@ func (s *Backend) setFakeMuxTxPool(txPoolAPI *eth.PublicTransactionPoolAPI) {
 	*realPtrToEventMux = mux
 }
 
-// updates the nonces in the RPC facing TxPool with some state containing up-to-date nonces
-func (s *Backend) UpdateNonces(stateWithNonces *state.ManagedState) {
+// updates the nonces in the RPC facing TxPool from PublicTransactionPoolAPI, which otherwise would become stale
+func (s *Backend) SetNoncesInAPI(nonces map[common.Address]uint64) {
 	stateToUpdate := s.apiFacingTxPool.State()
-	for addr, _ := range stateWithNonces.Accounts() {
-		stateToUpdate.SetNonce(addr, stateWithNonces.GetNonce(addr))
+	for addr, nonce := range nonces {
+		stateToUpdate.SetNonce(addr, nonce)
 	}
 }

--- a/vendor/github.com/ethereum/go-ethereum/core/state/managed_state.go
+++ b/vendor/github.com/ethereum/go-ethereum/core/state/managed_state.go
@@ -136,6 +136,10 @@ func (ms *ManagedState) getAccount(addr common.Address) *account {
 	return ms.accounts[addr]
 }
 
+func (ms *ManagedState) Accounts() map[common.Address]*account {
+	return ms.accounts
+}
+
 func newAccount(so *StateObject) *account {
 	return &account{so, so.Nonce(), nil}
 }

--- a/vendor/github.com/ethereum/go-ethereum/core/state/managed_state.go
+++ b/vendor/github.com/ethereum/go-ethereum/core/state/managed_state.go
@@ -136,10 +136,6 @@ func (ms *ManagedState) getAccount(addr common.Address) *account {
 	return ms.accounts[addr]
 }
 
-func (ms *ManagedState) Accounts() map[common.Address]*account {
-	return ms.accounts
-}
-
 func newAccount(so *StateObject) *account {
 	return &account{so, so.Nonce(), nil}
 }


### PR DESCRIPTION
This is a hacky workaround to temporarily fix issue #10. The account nonces that were processed correctly only in the `TxPool` on the `EthermintApplication` side, are now smuggled over to a `TxPool` which interacts with the `PublicTransactionPoolAPI` in `Commit`.