### PR TITLE
Fix broadcast tx before tendermint is ready

### DIFF
--- a/ethereum/backend.go
+++ b/ethereum/backend.go
@@ -3,6 +3,7 @@ package ethereum
 import (
 	"bytes"
 	"encoding/hex"
+	"os"
 	"reflect"
 	"time"
 	"unsafe"
@@ -20,6 +21,7 @@ import (
 
 	client "github.com/tendermint/go-rpc/client"
 	core_types "github.com/tendermint/tendermint/rpc/core/types"
+	tmspTypes "github.com/tendermint/tmsp/types"
 )
 
 // Backend handles the chain database and VM
@@ -29,6 +31,10 @@ type Backend struct {
 	client   *client.ClientURI
 	config   *eth.Config
 }
+
+const (
+	maxWaitForServerRetries = 10
+)
 
 // New creates a new Backend
 func NewBackend(ctx *node.ServiceContext, config *eth.Config) (*Backend, error) {
@@ -46,6 +52,23 @@ func NewBackend(ctx *node.ServiceContext, config *eth.Config) (*Backend, error) 
 	}
 
 	return ethBackend, nil
+}
+
+func waitForServer(s *Backend) error {
+	// wait for Tendermint to open the socket and run http endpoint
+	var result core_types.TMResult
+	retriesCount := 0
+	for result == nil {
+		_, err := s.client.Call("status", map[string]interface{}{}, &result)
+		if err != nil {
+			glog.V(logger.Info).Infof("Waiting for tendermint endpoint to start: %s", err)
+		}
+		if retriesCount++; retriesCount >= maxWaitForServerRetries {
+			return tmspTypes.ErrInternalError
+		}
+		time.Sleep(time.Second)
+	}
+	return nil
 }
 
 // APIs returns the collection of RPC services the ethereum package offers.
@@ -100,17 +123,9 @@ func (s *Backend) Config() *eth.Config {
 
 // listen for txs and forward to tendermint
 func (s *Backend) txBroadcastLoop() {
-
-	// wait for Tendermint to open the socket and run http endpoint
-	var result core_types.TMResult
-	for result == nil {
-		_, err := s.client.Call("status", map[string]interface{}{}, &result)
-		if err != nil {
-			glog.V(logger.Info).Infof("%s", err)
-		}
-		time.Sleep(time.Second)
+	if err := waitForServer(s); err != nil {
+		os.Exit(1)
 	}
-
 	for obj := range s.txSub.Chan() {
 		event := obj.Data.(core.TxPreEvent)
 		err := s.BroadcastTx(event.Tx)

--- a/ethereum/backend.go
+++ b/ethereum/backend.go
@@ -63,7 +63,7 @@ func waitForServer(s *Backend) error {
 		if err != nil {
 			glog.V(logger.Info).Infof("Waiting for tendermint endpoint to start: %s", err)
 		}
-		if retriesCount++; retriesCount >= maxWaitForServerRetries {
+		if retriesCount += 1; retriesCount >= maxWaitForServerRetries {
 			return tmspTypes.ErrInternalError
 		}
 		time.Sleep(time.Second)
@@ -124,6 +124,8 @@ func (s *Backend) Config() *eth.Config {
 // listen for txs and forward to tendermint
 func (s *Backend) txBroadcastLoop() {
 	if err := waitForServer(s); err != nil {
+		// timeouted when waiting for tendermint communication failed
+		glog.V(logger.Error).Infof("Failed to run tendermint HTTP endpoint, err=%s", err)
 		os.Exit(1)
 	}
 	for obj := range s.txSub.Chan() {


### PR DESCRIPTION
Hello,
when trying to send transactions to ethermint using RPC, if one sends a transaction too early before ethermint is fully up, the transaction just disappears. It is commited in go-ethereum, but when pushed to tendermint using `txBroadcastLoop` it raises an error:

```Post http://localhost:46657/broadcast_tx_sync: dial tcp 127.0.0.1:46657: getsockopt: connection refused```

which unfortunately [is ignored](https://github.com/tendermint/ethermint/blob/master/ethereum/backend.go#L105) and the user has no idea that the transaction didn't commit correctly, unless by waiting for a receipt (the receipt is never there). 

I propose a fix which is to wait for tendermint HTTP api before trying to push any transactions there. I wait trying to call `status`; to prevent from waiting forever, after a certain number of retries is done I suggest we just exit (the application does not work correctly at this point anyway).

I'm attaching a simple test that captures the behaviour:

a shell script:
```sh
#!/bin/sh

DATADIR=test_ethermint_datadir
mkdir -p "$DATADIR"

cp -avr geth_data/keystore "$DATADIR"
ethermint -datadir "${DATADIR}" init dev/genesis.json

ethermint --rpc --rpcaddr=0.0.0.0 --rpcapi "eth,net,web3,personal,admin" -datadir "${DATADIR}" > "${DATADIR}/logfile.log" &

geth --exec 'loadScript("sendTxAndGetReceipt.js")' attach http://localhost:8545
```

and `sendTxAndGetReceipt.js`:

```js
personal.unlockAccount(eth.accounts[0], "1234", 0);
value = 1000;
txnHash = eth.sendTransaction({'from': eth.accounts[0], 'to': "0x90a0a1aaaaa1a1936aff7aaf20a7878ff9e04b6a", 'value': value});
admin.sleepBlocks(3);
receipt = eth.getTransactionReceipt(txnHash);
console.log(JSON.stringify(receipt));
```

When run on current repo revision, the `console.log` outputs `null` receipt. With the fix, it outputs the correct receipt.