### PR TITLE
changes to have `tx` included into the block

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -131,12 +131,11 @@ func (app *EthermintApplication) validateTx(tx *ethTypes.Transaction) error {
 		return err
 	}
 
-	// TODO: only do once a block
-	blockchain := app.backend.Ethereum().BlockChain()
-	currentBlock := blockchain.CurrentBlock()
-	height := currentBlock.Number()
+	var signer ethTypes.Signer = ethTypes.FrontierSigner{}
+	if tx.Protected() {
+		signer = ethTypes.NewEIP155Signer(tx.ChainId())
+	}
 
-	signer := ethTypes.MakeSigner(blockchain.Config(), height)
 	from, err := ethTypes.Sender(signer, tx)
 	if err != nil {
 		return core.ErrInvalidSender

--- a/ethereum/backend.go
+++ b/ethereum/backend.go
@@ -2,7 +2,6 @@ package ethereum
 
 import (
 	"bytes"
-	"encoding/hex"
 	"reflect"
 	"unsafe"
 
@@ -57,10 +56,11 @@ func (s *Backend) APIs() []rpc.API {
 			s.setFakeTxPool(txPoolAPI)
 			go s.txBroadcastLoop()
 		}*/
-		// TODO: do we need to overwrite the txPool ?!
-		go s.txBroadcastLoop()
 		retApis = append(retApis, v)
 	}
+
+	// TODO: do we need to overwrite the txPool ?!
+	go s.txBroadcastLoop()
 	return retApis
 }
 
@@ -116,7 +116,7 @@ func (s *Backend) BroadcastTx(tx *ethTypes.Transaction) error {
 		return err
 	}
 	params := map[string]interface{}{
-		"tx": hex.EncodeToString(buf.Bytes()),
+		"tx": buf.Bytes(),
 	}
 	_, err := s.client.Call("broadcast_tx_sync", params, &result)
 	return err


### PR DESCRIPTION
Minor changes:
- [x] simple `Signer`
- [x] `txBroadcastLoop` moved out of loop
- [x] no `hex.EncodeToString` before the API `broadcast_tx_sync` call 
- [ ] overall success 