### PR TITLE
ABCI Query Impl + Reorder startup logic

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,7 +2,7 @@ package app
 
 import (
 	"bytes"
-	//"encoding/json"
+	"encoding/json"
 	"math/big"
 	"sync"
 
@@ -301,19 +301,11 @@ func (app *EthermintApplication) Commit() abciTypes.Result {
 	return abciTypes.NewResultOK(blockHash[:], "")
 }
 
-// TODO
-func (app *EthermintApplication) Query(query []byte) abciTypes.Result {
-	return abciTypes.Result{}
-}
-
-/*
 type jsonRequest struct {
 	Method  string          `json:"method"`
-	Version string          `json:"jsonrpc"`
 	Id      json.RawMessage `json:"id,omitempty"`
-	Payload json.RawMessage `json:"params,omitempty"`
+	Params []interface{}	`json:"params,omitempty"`
 }
-
 
 // Query queries the state of EthermintApplication
 func (app *EthermintApplication) Query(query []byte) abciTypes.Result {
@@ -321,12 +313,9 @@ func (app *EthermintApplication) Query(query []byte) abciTypes.Result {
 	if err := json.Unmarshal(query, &in); err != nil {
 		return abciTypes.ErrInternalError
 	}
-	if err := app.rpcClient.Send(in); err != nil {
-		return abciTypes.ErrInternalError
-	}
-	result := make(map[string]interface{})
-	if err := app.rpcClient.Recv(&result); err != nil {
-		return abciTypes.ErrInternalError
+	var result interface{}
+	if err := app.rpcClient.Call(&result, in.Method, in.Params...); err != nil {
+		return abciTypes.NewError(abciTypes.ErrInternalError.Code, err.Error())
 	}
 	bytes, err := json.Marshal(result)
 	if err != nil {
@@ -334,7 +323,6 @@ func (app *EthermintApplication) Query(query []byte) abciTypes.Result {
 	}
 	return abciTypes.NewResultOK(bytes, "")
 }
-*/
 
 //----------------------------------------------------------------------------
 


### PR DESCRIPTION
- [x] ABCI Query Impl
- [x] Reorder startup logic

request:
```
http://localhost:46657/abci_query?query="{\"jsonrpc\":\"2.0\",\"method\":\"eth_coinbase\",\"params\":[],\"id\":1}"
```
response:
```
{
  "jsonrpc": "2.0",
  "id": "",
  "result": [
    112,
    {
      "result": {
        "Code": 0,
        "Data": "2230783765666631323262393438393765613562306532613961626634376238363333376661666562646322",
        "Log": ""
      }
    }
  ],
  "error": ""
}
```
where `2230783765666631323262393438393765613562306532613961626634376238363333376661666562646322` is `"0x7eff122b94897ea5b0e2a9abf47b86337fafebdc"` in HEX

request:
```
http://localhost:46657/abci_query?query="{\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x7eff122b94897ea5b0e2a9abf47b86337fafebdc\", \"latest\"],\"id\":2}"
```
response:
```
{
  "jsonrpc": "2.0",
  "id": "",
  "result": [
    112,
    {
      "result": {
        "Code": 0,
        "Data": "2230786639386322",
        "Log": ""
      }
    }
  ],
  "error": ""
}
```
where `2230786639386322` is `"0xf98c"` in HEX

request:
```
http://localhost:46657/abci_query?query="{\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionCount\",\"params\":[\"0x7eff122b94897ea5b0e2a9abf47b86337fafebdc\"],\"id\":68}"
```
response:
```
{
  "jsonrpc": "2.0",
  "id": "",
  "result": [
    112,
    {
      "result": {
        "Code": 1,
        "Data": "",
        "Log": "missing value for required argument 1"
      }
    }
  ],
  "error": ""
}
```