### PR TITLE
#51 enable web3 API by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,10 @@ get_deps:
 get_vendor_deps:
 	go get github.com/Masterminds/glide
 	glide install --strip-vendor
+
+docker_build:
+	rm -rf ./docker/ethermint
+	docker run -it --rm -v "$(PWD):/go/src/github.com/tendermint/ethermint" -w "/go/src/github.com/tendermint/ethermint" \
+        golang:1.6 go build --ldflags '-extldflags "-static"' \
+        -o /go/src/github.com/tendermint/ethermint/docker/ethermint ./cmd/ethermint/
+	docker build -t "tendermint/ethermint" ./docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,33 @@
-FROM golang:1.6
+FROM alpine:latest
 MAINTAINER ethan@tendermint.com
+# Where to install binaries
+ENV INSTALL_BASE /usr/local/bin
 
-RUN curl https://glide.sh/get | sh
-RUN go get github.com/tendermint/ethermint/cmd/ethermint
+# User Creation
+# Choose the user id number 1000 to work well with Boot2Docker volumes.  See:
+# https://github.com/boot2docker/boot2docker/issues/581#issuecomment-62491280
+ENV USER ethermint
+RUN addgroup -S $USER && adduser -s /bin/bash -S -D -u 1000 $USER $USER
+RUN chown $USER /var/run
 
-RUN mkdir /ethermint && chmod 777 /ethermint
-RUN useradd -ms /bin/bash ethermint
-RUN chown ethermint /var/run
-USER ethermint 
 
-RUN mkdir -p /ethermint/setup
+RUN mkdir /ethermint && \
+  mkdir /ethermint/setup && \
+  chown --recursive $USER:$USER /ethermint
+
+
+COPY ./ethermint $INSTALL_BASE/ethermint
+RUN chmod +x $INSTALL_BASE/ethermint
+
+USER $USER
+
 COPY genesis.json /ethermint/setup/
 RUN ethermint -datadir /ethermint/data init /ethermint/setup/genesis.json
 COPY keystore /ethermint/data/keystore
-EXPOSE 8545
 
-CMD ["ethermint", "-datadir", "/ethermint/data"]
+EXPOSE 8545
+EXPOSE 46656
+EXPOSE 46657
+EXPOSE 46658
+
+CMD ["ethermint", "--datadir=/ethermint/data", "--rpc", "--rpcaddr=0.0.0.0", "--rpcapi", "eth,net,web3,personal,admin"]


### PR DESCRIPTION
- enable web3 API by default
- separate building and running images (golang for building, alpine for running)
- final docker image takes only 87.5 MB