### PR TITLE
NetRPCService service

### DIFF
--- a/ethereum/api.go
+++ b/ethereum/api.go
@@ -17,12 +17,12 @@ func NewNetRPCService(networkVersion int) *NetRPCService {
 }
 
 // Listening returns an indication if the node is listening for network connections.
-func (s *NetRPCService) Listening() bool {
+func (n *NetRPCService) Listening() bool {
 	return true // always listening
 }
 
 // PeerCount returns the number of connected peers
-func (s *NetRPCService) PeerCount() hexutil.Uint {
+func (n *NetRPCService) PeerCount() hexutil.Uint {
 	return hexutil.Uint(0)
 }
 

--- a/ethereum/api.go
+++ b/ethereum/api.go
@@ -1,0 +1,32 @@
+package ethereum
+
+import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// We must implement our own net service since we don't have access to `internal/ethapi`
+
+type NetRPCService struct {
+	networkVersion int
+}
+
+// NewNetRPCService creates a new net API instance.
+func NewNetRPCService(networkVersion int) *NetRPCService {
+	return &NetRPCService{networkVersion}
+}
+
+// Listening returns an indication if the node is listening for network connections.
+func (s *NetRPCService) Listening() bool {
+	return true // always listening
+}
+
+// PeerCount returns the number of connected peers
+func (s *NetRPCService) PeerCount() hexutil.Uint {
+	return hexutil.Uint(0)
+}
+
+// Version returns the current ethereum protocol version.
+func (n *NetRPCService) Version() string {
+	return fmt.Sprintf("%d", n.networkVersion)
+}

--- a/ethereum/backend.go
+++ b/ethereum/backend.go
@@ -1,7 +1,6 @@
 package ethereum
 
 import (
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -104,8 +103,7 @@ func (s *Backend) APIs() []rpc.API {
 	retApis := []rpc.API{}
 	for _, v := range apis {
 		if v.Namespace == "net" {
-			networkVersion := 1 // TODO: this should come from a flag
-			v.Service = &NetRPCService{networkVersion}
+			v.Service = NewNetRPCService(s.config.NetworkId)
 		}
 		if v.Namespace == "miner" {
 			continue
@@ -136,17 +134,6 @@ func (s *Backend) Stop() error {
 // network protocols to start.
 func (s *Backend) Protocols() []p2p.Protocol {
 	return nil
-}
-
-//----------------------------------------------------------------------
-// We must implement our own net service since we don't have access to `internal/ethapi`
-
-type NetRPCService struct {
-	networkVersion int
-}
-
-func (n *NetRPCService) Version() string {
-	return fmt.Sprintf("%d", n.networkVersion)
 }
 
 //----------------------------------------------------------------------


### PR DESCRIPTION
NetRPCService service:
* version from config (`--networkid`)
* `listening` and `peerCount` API

![image](https://cloud.githubusercontent.com/assets/1008882/25913560/df402204-35c3-11e7-98fc-54a4e3e76f64.png)

Issue: https://github.com/tendermint/ethermint/issues/74