### PR TITLE
Unify logging

### DIFF
--- a/cmd/ethermint/ethermint.go
+++ b/cmd/ethermint/ethermint.go
@@ -22,7 +22,6 @@ import (
 	"github.com/tendermint/abci/server"
 
 	cmn "github.com/tendermint/tmlibs/common"
-	tmlog "github.com/tendermint/tmlibs/log"
 )
 
 func ethermintCmd(ctx *cli.Context) error {
@@ -60,8 +59,7 @@ func ethermintCmd(ctx *cli.Context) error {
 		os.Exit(1)
 	}
 
-	logger := tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout))
-	srv.SetLogger(logger.With("module", "abci-server"))
+	srv.SetLogger(emtUtils.GetTMLogger().With("module", "abci-server"))
 
 	if _, err := srv.Start(); err != nil {
 		fmt.Println(err)

--- a/cmd/utils/log.go
+++ b/cmd/utils/log.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/log/term"
+	tmlog "github.com/tendermint/tmlibs/log"
 )
 
 var glogger *log.GlogHandler
@@ -29,4 +30,47 @@ func Setup(ctx *cli.Context) error {
 	log.Root().SetHandler(glogger)
 
 	return nil
+}
+
+func GetTMLogger() tmlog.Logger {
+	return NewTMEthereumProxyLogger()
+}
+
+// Interface assertions
+var _ tmlog.Logger = (*tmEthereumProxyLogger)(nil)
+
+func NewTMEthereumProxyLogger() tmlog.Logger {
+	logger := tmEthereumProxyLogger{}
+	return logger
+}
+
+type tmEthereumProxyLogger struct {
+	keyvals []interface{}
+}
+
+func (l tmEthereumProxyLogger) Debug(msg string, ctx ...interface{}) error {
+	ctx = append(l.keyvals, ctx...)
+	log.Debug(msg, ctx...)
+	return nil
+}
+
+func (l tmEthereumProxyLogger) Info(msg string, ctx ...interface{}) error {
+	ctx = append(l.keyvals, ctx...)
+	log.Info(msg, ctx...)
+	return nil
+}
+
+func (l tmEthereumProxyLogger) Error(msg string, ctx ...interface{}) error {
+	ctx = append(l.keyvals, ctx...)
+	log.Error(msg, ctx...)
+	return nil
+}
+
+func (l tmEthereumProxyLogger) With(ctx ...interface{}) tmlog.Logger {
+	logger := &tmEthereumProxyLogger{}
+	logger.keyvals = make([]interface{}, 0, len(l.keyvals)+len(ctx))
+	logger.keyvals = append(logger.keyvals, l.keyvals...)
+	logger.keyvals = append(logger.keyvals, ctx...)
+
+	return logger
 }


### PR DESCRIPTION
It will proxy all logs from TMLIB/ABCI server to ethereum logger.
`--verbosity` will affect abci too.