### PR TITLE
Emhome environment variable

### DIFF
--- a/cmd/ethermint/init.go
+++ b/cmd/ethermint/init.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 
 	ethUtils "github.com/ethereum/go-ethereum/cmd/utils"
+	emtUtils "github.com/tendermint/ethermint/cmd/utils"
+
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -34,7 +36,7 @@ func initCmd(ctx *cli.Context) error {
 		ethUtils.Fatalf("invalid genesis file: %v", err)
 	}
 
-	chainDb, err := ethdb.NewLDBDatabase(filepath.Join(ethUtils.MakeDataDir(ctx), "ethermint/chaindata"), 0, 0)
+	chainDb, err := ethdb.NewLDBDatabase(filepath.Join(emtUtils.MakeDataDir(ctx), "ethermint/chaindata"), 0, 0)
 	if err != nil {
 		ethUtils.Fatalf("could not open database: %v", err)
 	}

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	cli "gopkg.in/urfave/cli.v1"
 	"math/big"
+	"os"
 
 	"github.com/tendermint/ethermint/ethereum"
 
@@ -15,6 +16,8 @@ import (
 const (
 	// Client identifier to advertise over the network
 	clientIdentifier = "ethermint"
+	// Environment variable for home dir
+	emHome = "EMHOME"
 )
 
 var (
@@ -72,6 +75,12 @@ func DefaultNodeConfig() node.Config {
 	cfg.HTTPModules = append(cfg.HTTPModules, "eth")
 	cfg.WSModules = append(cfg.WSModules, "eth")
 	cfg.IPCPath = "geth.ipc"
+
+	emHome := os.Getenv(emHome)
+	if emHome != "" {
+		cfg.DataDir = emHome
+	}
+
 	return cfg
 }
 
@@ -85,4 +94,24 @@ func SetEthermintNodeConfig(cfg *node.Config) {
 func SetEthermintEthConfig(cfg *eth.Config) {
 	cfg.MaxPeers = 0
 	cfg.PowFake = true
+}
+
+// MakeDataDir retrieves the currently requested data directory
+func MakeDataDir(ctx *cli.Context) string {
+	path := node.DefaultDataDir()
+
+	emHome := os.Getenv(emHome)
+	if emHome != "" {
+		path = emHome
+	}
+
+	if ctx.GlobalIsSet(ethUtils.DataDirFlag.Name) {
+		path = ctx.GlobalString(ethUtils.DataDirFlag.Name)
+	}
+
+	if path == "" {
+		ethUtils.Fatalf("Cannot determine default data directory, please set manually (--datadir)")
+	}
+
+	return path
 }

--- a/cmd/utils/config_test.go
+++ b/cmd/utils/config_test.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"flag"
+	"gopkg.in/urfave/cli.v1"
+	"os"
+	"testing"
+	"github.com/ethereum/go-ethereum/node"
+)
+
+// we use EMHOME env variable if don't set datadir flag
+func TestEMHome(t *testing.T) {
+	// set env variable
+	emHomedir := "/tmp/dir1"
+	os.Setenv(emHome, emHomedir)
+
+	// context with empty flag set
+	context := getContextNoFlag()
+
+	_, config := makeConfigNode(context)
+
+	if config.Node.DataDir != emHomedir {
+		t.Errorf("DataDir is wrong: %s", config.Node.DataDir)
+	}
+}
+
+func TestEmHomeDataDir(t *testing.T) {
+	// set env variable
+	emHomedir := "/tmp/dir1"
+	os.Setenv(emHome, emHomedir)
+
+	// context with datadir flag
+	dir := "/tmp/dir2"
+	context := getContextDataDirFlag(dir)
+
+	_, config := makeConfigNode(context)
+
+	if config.Node.DataDir != dir {
+		t.Errorf("DataDir is wrong: %s", config.Node.DataDir)
+	}
+}
+
+// init cli.context with empty flag set
+func getContextNoFlag() *cli.Context {
+	set := flag.NewFlagSet("test", 0)
+	globalSet := flag.NewFlagSet("test", 0)
+
+	globalCtx := cli.NewContext(nil, globalSet, nil)
+	ctx := cli.NewContext(nil, set, globalCtx)
+
+	return ctx
+}
+
+func getContextDataDirFlag(dir string) *cli.Context {
+	set := flag.NewFlagSet("test", 0)
+	globalSet := flag.NewFlagSet("test", 0)
+	globalSet.String("datadir", node.DefaultDataDir(), "doc")
+
+	globalCtx := cli.NewContext(nil, globalSet, nil)
+	ctx := cli.NewContext(nil, set, globalCtx)
+
+	globalSet.Parse([]string{"--datadir", dir})
+
+	return ctx
+}


### PR DESCRIPTION
Added `EMHOME` env variable. Examples:

`EMHOME=~/aaa1 ethermint init setup/genesis.json`

`EMHOME=~/aaa1 ethermint --rpc --rpcaddr=0.0.0.0 --ws --wsaddr=0.0.0.0 --rpcapi eth,net,web3,personal,admin`

Issue: https://github.com/tendermint/ethermint/issues/169