### PR TITLE
CONTRIBUTING.md file added

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,13 @@
 ## Pull Requests
+If you are working directly on this repository instead of forking it, please make sure
+that you follow the [git-flow](http://nvie.com/posts/a-successful-git-branching-model/)
+naming convention. 
+Your branch should start with `feature/your_feature_name`.
+
 If opening a PR against Ethermint, please use branch `develop` as the base branch
 for changes. 
 `unstable` should only be used to integrate multiple PRs that might have effects on each other.
+
+Please make sure that all tests run with `make test` pass.
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+## Pull Requests
+If opening a PR against Ethermint, please use branch `develop` as the base branch
+for changes. 
+`unstable` should only be used to integrate multiple PRs that might have effects on each other.


### PR DESCRIPTION
When I started hacking on the project, I did not have
any direction on which branch to contribute to.
Offline I got a direct message that our new convention
is that PRs to this project should use develop as the
base and that unstable should only be used to merge
multiple PRs that have effects on each other.

Let's actually cement this so that it isn't by
word of mouth and that anyone can pick it up.

This was decided by @jaekwon and then relayed to me by @adrianbrink. 