### PR TITLE
ethereum: fix nil dereferences in node.New*Config and add tests

### DIFF
--- a/ethereum/node.go
+++ b/ethereum/node.go
@@ -11,7 +11,7 @@ import (
 // NewNodeConfig for p2p and network layer
 // #unstable
 func NewNodeConfig(ctx *cli.Context) *node.Config {
-	var nodeConfig *node.Config
+	nodeConfig := new(node.Config)
 	ethUtils.SetNodeConfig(ctx, nodeConfig)
 
 	return nodeConfig
@@ -20,7 +20,7 @@ func NewNodeConfig(ctx *cli.Context) *node.Config {
 // NewEthConfig for the ethereum services
 // #unstable
 func NewEthConfig(ctx *cli.Context, stack *node.Node) *eth.Config {
-	var ethConfig *eth.Config
+	ethConfig := new(eth.Config)
 	ethUtils.SetEthConfig(ctx, stack, ethConfig)
 
 	return ethConfig

--- a/ethereum/node_test.go
+++ b/ethereum/node_test.go
@@ -1,0 +1,40 @@
+package ethereum_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/urfave/cli.v1"
+
+	"github.com/tendermint/ethermint/ethereum"
+)
+
+var dummyApp = &cli.App{
+	Name:   "test",
+	Author: "Tendermint",
+}
+
+var dummyContext = cli.NewContext(dummyApp, flag.NewFlagSet("test", flag.ContinueOnError), nil)
+var dummyNode, _ = node.New(&node.DefaultConfig)
+
+func TestNewNodeConfig(t *testing.T) {
+	defer func() {
+		err := recover()
+		assert.Nil(t, err, "expecting no panics")
+	}()
+
+	ncfg := ethereum.NewNodeConfig(dummyContext)
+	assert.NotNil(t, ncfg, "expecting a non-nil config")
+}
+
+func TestNewEthConfig(t *testing.T) {
+	defer func() {
+		err := recover()
+		assert.Nil(t, err, "expecting no panics")
+	}()
+
+	ecfg := ethereum.NewEthConfig(dummyContext, dummyNode)
+	assert.NotNil(t, ecfg, "expecting a non-nil config")
+}


### PR DESCRIPTION
There are public functions:
- NewEthConfig
- NewNodeConfig

that both pass in a nil *eth.Config and *node.Config respectively.
Unfortunately those variables are nil and when invoked panic with
a nil dereference. Fix this with a proper allocation and
include tests to ensure that we never regress nor panic.