### PR TITLE
Disable p2p ethereum network from starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the change was necessary due to a change in the API exposed by geth
 * better documentation
 * proper linting and error detection
   * can be accessed with `make metalinter` and `make megacheck`
+* ethereum node p2p server does not get started anymore
 
 
 ## 0.3.0 (June 23, 2017)

--- a/cmd/ethermint/ethermint.go
+++ b/cmd/ethermint/ethermint.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/console"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/node"
 
 	abciApp "github.com/tendermint/ethermint/app"
 	emtUtils "github.com/tendermint/ethermint/cmd/utils"
@@ -76,8 +75,8 @@ func ethermintCmd(ctx *cli.Context) error {
 
 // nolint
 // startNode copies the logic from go-ethereum
-func startNode(ctx *cli.Context, stack *node.Node) {
-	ethUtils.StartNode(stack)
+func startNode(ctx *cli.Context, stack *ethereum.Node) {
+	emtUtils.StartNode(stack)
 
 	// Unlock any account specifically requested
 	ks := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -41,7 +41,7 @@ type gethConfig struct {
 
 // MakeFullNode creates a full go-ethereum node
 // #unstable
-func MakeFullNode(ctx *cli.Context) *node.Node {
+func MakeFullNode(ctx *cli.Context) *ethereum.Node {
 	stack, cfg := makeConfigNode(ctx)
 
 	tendermintLAddr := ctx.GlobalString(TendermintAddrFlag.Name)
@@ -54,7 +54,7 @@ func MakeFullNode(ctx *cli.Context) *node.Node {
 	return stack
 }
 
-func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
+func makeConfigNode(ctx *cli.Context) (*ethereum.Node, gethConfig) {
 	cfg := gethConfig{
 		Eth:  eth.DefaultConfig,
 		Node: DefaultNodeConfig(),
@@ -62,12 +62,12 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 
 	ethUtils.SetNodeConfig(ctx, &cfg.Node)
 	SetEthermintNodeConfig(&cfg.Node)
-	stack, err := node.New(&cfg.Node)
+	stack, err := ethereum.New(&cfg.Node)
 	if err != nil {
 		ethUtils.Fatalf("Failed to create the protocol stack: %v", err)
 	}
 
-	ethUtils.SetEthConfig(ctx, stack, &cfg.Eth)
+	ethUtils.SetEthConfig(ctx, &stack.Node, &cfg.Eth)
 	SetEthermintEthConfig(&cfg.Eth)
 
 	return stack, cfg

--- a/ethereum/backend.go
+++ b/ethereum/backend.go
@@ -148,7 +148,7 @@ func (b *Backend) APIs() []rpc.API {
 // Start implements node.Service, starting all internal goroutines needed by the
 // Ethereum protocol implementation.
 // #stable
-func (b *Backend) Start(srvr *p2p.Server) error {
+func (b *Backend) Start(_ *p2p.Server) error {
 	go b.txBroadcastLoop()
 	return nil
 }

--- a/ethereum/node.go
+++ b/ethereum/node.go
@@ -8,6 +8,33 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 )
 
+type Node struct {
+	node.Node
+}
+
+func New(conf *node.Config) (*Node, error) {
+	stack, err := node.New(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Node{*stack}, nil
+}
+
+// Start starts base node and stop p2p server
+func (n *Node) Start() error {
+	// start p2p server
+	err := n.Node.Start()
+	if err != nil {
+		return err
+	}
+
+	// stop it
+	n.Node.Server().Stop()
+
+	return nil
+}
+
 // NewNodeConfig for p2p and network layer
 // #unstable
 func NewNodeConfig(ctx *cli.Context) *node.Config {

--- a/ethereum/node_test.go
+++ b/ethereum/node_test.go
@@ -2,11 +2,14 @@ package ethereum_test
 
 import (
 	"flag"
+	"net"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/node"
-	"github.com/stretchr/testify/assert"
 	"gopkg.in/urfave/cli.v1"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ethereum/go-ethereum/node"
 
 	"github.com/tendermint/ethermint/ethereum"
 )
@@ -37,4 +40,29 @@ func TestNewEthConfig(t *testing.T) {
 
 	ecfg := ethereum.NewEthConfig(dummyContext, dummyNode)
 	assert.NotNil(t, ecfg, "expecting a non-nil config")
+}
+
+func TestEnsureDisabledEthereumP2PStack(t *testing.T) {
+	cfg := new(node.Config)
+	*cfg = node.DefaultConfig
+	cfg.P2P.ListenAddr = ":34555"
+	node, err := ethereum.New(cfg)
+	if err != nil {
+		t.Fatalf("cannot initialise new node from config: %v", err)
+	}
+
+	node.Start()
+	if err != nil {
+		t.Fatalf("cannot start node: %v", err)
+	}
+	// Make a listener and ensure that ListenAddr can be bound to
+	// i.e that no other service is listening on it
+	addr := cfg.P2P.ListenAddr
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("failed to bind to %q: %v", addr, err)
+	}
+	if err := listener.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
 }


### PR DESCRIPTION
This PR introduces the following changes:
* we have a wrapper around an ethereum node
  * it starts and then stops the ethereum p2p networking stack
  * it will be helpful in migrating away from the standard ethereum node and towards a custom build ethereum layer