### PR TITLE
Allow networkId as a parameter

### DIFF
--- a/cmd/ethermint/main.go
+++ b/cmd/ethermint/main.go
@@ -36,6 +36,8 @@ var (
 		utils.TargetGasLimitFlag,
 		// Gas Price
 		ethUtils.GasPriceFlag,
+		// Network ID
+		ethUtils.NetworkIdFlag
 	}
 
 	rpcFlags = []cli.Flag{


### PR DESCRIPTION
Moved from #324 

Fixes #214
Related to #81

Metamask was not taking in consideration networkId until recent updates. Its related to EIP https://github.com/ethereum/eips/issues/155 & MetaMask/metamask-extension#1722 (comment)