### PR TITLE
docs(install): Add tapping before brewing

### DIFF
--- a/docs/getting-started/install.rst
+++ b/docs/getting-started/install.rst
@@ -18,6 +18,7 @@ MacOS
 
 ::
 
+    brew tap tendermint/homebrew-tendermint
     brew install ethermint
 
 Windows


### PR DESCRIPTION
## Description
Relates to: 

Add `brew tap` before `brew install` to make it easier for developers to install.

## Checklist
- [x] Update the documentation/architecture to reflect the changes
- [x] Merge this PR by squashing.
- [ ] Close any related issues once this PR is merged.
- [ ] Remove the original branch once the PR is merged.
