### PR TITLE
Implement BlockKeeper for RPC-compatible block storage

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -780,6 +780,7 @@
     "github.com/ethereum/go-ethereum/consensus/ethash",
     "github.com/ethereum/go-ethereum/consensus/misc",
     "github.com/ethereum/go-ethereum/core",
+    "github.com/ethereum/go-ethereum/core/rawdb",
     "github.com/ethereum/go-ethereum/core/state",
     "github.com/ethereum/go-ethereum/core/types",
     "github.com/ethereum/go-ethereum/core/vm",

--- a/x/evm/types/block_keeper.go
+++ b/x/evm/types/block_keeper.go
@@ -1,0 +1,98 @@
+package types
+
+import (
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+)
+
+// BlockKeeper persists blocks in a manner consistent with how
+// the RPC latyer will query them.
+type BlockKeeper struct {
+	// The key used to access the store from the Context.
+	key types.StoreKey
+
+	// The codec for binary encoding/decoding of blocks.
+	cdc *codec.Codec
+}
+
+func NewBlockKeeper(key types.StoreKey, cdc *codec.Codec) *BlockKeeper {
+	return &BlockKeeper{
+		key: key,
+		cdc: cdc,
+	}
+}
+
+// GetBlockByNumber returns a persisted Ethereum block by its number.
+func (bk *BlockKeeper) GetBlockByNumber(ctx types.Context, blockNum uint64) *ethtypes.Block {
+	wrapper := bk.wrapKVStore(ctx.KVStore(bk.key))
+	hash := rawdb.ReadCanonicalHash(wrapper, blockNum)
+	return bk.getBlock(wrapper, hash, blockNum)
+}
+
+// GetBlockByHash returns a persisted Ethereum block by its hash.
+func (bk *BlockKeeper) GetBlockByHash(ctx types.Context, hash common.Hash) *ethtypes.Block {
+	wrapper := bk.wrapKVStore(ctx.KVStore(bk.key))
+	number := *rawdb.ReadHeaderNumber(wrapper, hash)
+	return bk.getBlock(wrapper, hash, number)
+}
+
+// SetBlock persists an Ethereum block.
+// TODO @mslipper: Transaction receipts need to be included separately.
+func (bk *BlockKeeper) SetBlock(ctx types.Context, block *ethtypes.Block) {
+	store := ctx.KVStore(bk.key)
+	wrapper := bk.wrapKVStore(store)
+	rawdb.WriteCanonicalHash(wrapper, block.Hash(), block.NumberU64())
+	rawdb.WriteHeader(wrapper, block.Header())
+	rawdb.WriteBlock(wrapper, block)
+}
+
+func (bk *BlockKeeper) getBlock(wrapper rawDBWrapper, hash common.Hash, number uint64) *ethtypes.Block {
+	return rawdb.ReadBlock(wrapper, hash, number)
+}
+
+func (bk *BlockKeeper) wrapKVStore(store types.KVStore) rawDBWrapper {
+	return &wrapper{store, bk}
+}
+
+// rawDBWrapper is a composite interface that wraps Geth's
+// DatabaseReader/Writer/Deleter interfaces. It allows Keeper
+// instances to work with Geth's rawdb package.
+type rawDBWrapper interface {
+	rawdb.DatabaseReader
+	rawdb.DatabaseWriter
+	rawdb.DatabaseDeleter
+}
+
+// wrapper takes a Keeper and a KVStore and creates a
+// rawDBWrapper-compatible data store.
+type wrapper struct {
+	store  types.KVStore
+	keeper *BlockKeeper
+}
+
+// Get gets a value for a given key from the backing store. Implements
+// Geth's DatabaseReader interface for lookups.
+func (w *wrapper) Get(key []byte) (value []byte, err error) {
+	return w.store.Get(key), nil
+}
+
+// Has checks for a given key 's existence in the backing store. Implements
+// Geth's DatabaseReader interface for lookups.
+func (w *wrapper) Has(key []byte) (bool, error) {
+	return w.store.Has(key), nil
+}
+
+// Put inserts a given key into the backing store. Implements Geth's
+// DatabaseWriter interface for persistence.
+func (w *wrapper) Put(key []byte, value []byte) error {
+	w.store.Set(key, value)
+	return nil
+}
+
+func (w *wrapper) Delete(key []byte) error {
+	w.store.Delete(key)
+	return nil
+}

--- a/x/evm/types/block_keeper_test.go
+++ b/x/evm/types/block_keeper_test.go
@@ -1,0 +1,72 @@
+package types
+
+import (
+	"github.com/stretchr/testify/suite"
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	dbm "github.com/tendermint/tendermint/libs/db"
+	"github.com/cosmos/cosmos-sdk/store"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/libs/log"
+	"testing"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"math/big"
+	"crypto/rand"
+	"github.com/stretchr/testify/require"
+)
+
+type bkTestSuite struct {
+	suite.Suite
+	ctx    types.Context
+	keeper *BlockKeeper
+}
+
+func (s *bkTestSuite) SetupSuite() {
+	cdc := codec.New()
+	db := dbm.NewMemDB()
+	ms := store.NewCommitMultiStore(db)
+	key := types.NewKVStoreKey("bk")
+	ms.MountStoreWithDB(key, types.StoreTypeIAVL, nil)
+	err := ms.LoadLatestVersion()
+	require.NoError(s.T(), err)
+	s.ctx = types.NewContext(ms, abci.Header{}, false, log.NewNopLogger())
+	s.keeper = NewBlockKeeper(key, cdc)
+}
+
+func (s *bkTestSuite) TestGetBlockByNumber() {
+	block := randomBlock(s.T())
+	s.keeper.SetBlock(s.ctx, block)
+	retBlock := s.keeper.GetBlockByNumber(s.ctx, block.NumberU64())
+	require.Equal(s.T(), block.Hash(), retBlock.Hash())
+	require.Equal(s.T(), block.NumberU64(), retBlock.NumberU64())
+}
+
+func (s *bkTestSuite) TestGetBlockByHash() {
+	block := randomBlock(s.T())
+	s.keeper.SetBlock(s.ctx, block)
+	retBlock := s.keeper.GetBlockByHash(s.ctx, block.Hash())
+	require.Equal(s.T(), block.Hash(), retBlock.Hash())
+	require.Equal(s.T(), block.NumberU64(), retBlock.NumberU64())
+}
+
+func TestBlockKeeper(t *testing.T) {
+	suite.Run(t, new(bkTestSuite))
+}
+
+func randomBlock(t *testing.T) *ethtypes.Block {
+	var nonce ethtypes.BlockNonce
+	copy(nonce[:], randBytes(t, 8))
+	num, err := rand.Int(rand.Reader, big.NewInt(10000))
+	require.NoError(t, err)
+	return ethtypes.NewBlock(&ethtypes.Header{
+		Number: num,
+		Nonce:  nonce,
+	}, nil, nil, nil)
+}
+
+func randBytes(t *testing.T, len int) []byte {
+	buf := make([]byte, len, len)
+	_, err := rand.Read(buf)
+	require.NoError(t, err)
+	return buf
+}


### PR DESCRIPTION
This PR implements the BlockKeeper storage construct as discussed during last week's Ethermint standup. A couple things to note:

1. I'm not 100% clear on the various backing store implementations - i.e., `CacheMultiStore`, `CommitMultiStore`, etc. @alexanderbez would love to pick your brain on what each one does so that I can use the appropriate one here.
2. I'm using Geth's `rawdb` package to make short work of persisting blocks in a manner that'll make querying them easy. Under the hood, `rawdb` persists everything in RLP. I know we discussed using Amino for everything under-the-hood, but given that another one of the project's stated goals is to reuse as much code from Geth as possible I thought that the additional code reuse `rawdb` provided was an OK tradeoff.
3. I see that the EVM/ABCI application is now implemented. @alexanderbez - would also like to discuss the best way to instantiate this Keeper in that context.
4. Transaction receipts will be a bit tricky, and will be handled in a separate PR after this one since they are generated from consensus and not the materialized list of block transactions.

I'd imagine that the `SetBlock` method would be called in the `EndBlocker` ABCI method.

Once I get the go-ahead for this PR, implementing the block retrieval methods within the RPC layer is trivial.